### PR TITLE
Added configuration feature for ignoring proxy configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 build
 *.ipr
 *.iws
+.project
+.settings

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ pluginBundle {
             id = 'org.tenne.rest'
             displayName = 'REST Gradle Plugin'
             tags = ['REST', 'API']
-            version = '0.4.2'
+            version = '0.5.0'
         }
     }
 

--- a/src/main/groovy/org/_10ne/gradle/rest/RestTask.groovy
+++ b/src/main/groovy/org/_10ne/gradle/rest/RestTask.groovy
@@ -50,6 +50,10 @@ class RestTask extends DefaultTask {
 
     @Input
     @Optional
+    boolean ignoreProxySettings
+
+    @Input
+    @Optional
     String username
 
     @Input
@@ -79,6 +83,7 @@ class RestTask extends DefaultTask {
     HttpResponseDecorator serverResponse
 
     RestTask() {
+        ignoreProxySettings = false
         httpMethod = 'get'
         client = new RESTClient()
     }
@@ -106,8 +111,10 @@ class RestTask extends DefaultTask {
             client.auth.basic(username, password)
         }
 
-        configureProxy('http')
-        configureProxy('https')
+        if(!ignoreProxySettings) {            
+            configureProxy('http')
+            configureProxy('https')
+        }
 
         if (requestHeaders instanceof Map) {
             client.headers.putAll(requestHeaders);


### PR DESCRIPTION
Since there was no easy way to add in nonProxyHosts, I just created a configuration parameter to ignore proxy settings in the plugin. A new spec was also added to verify this behavior.
